### PR TITLE
chore: import repository https://github.com/GalaxyiPhone/spring-boot-gradle-for-jx.git

### DIFF
--- a/.jx/gitops/source-config.yaml
+++ b/.jx/gitops/source-config.yaml
@@ -10,6 +10,12 @@ spec:
     repositories:
     - name: spring-boot-for-jx
     scheduler: in-repo
+  - owner: GalaxyiPhone
+    provider: https://github.com
+    providerKind: github
+    repositories:
+    - name: spring-boot-gradle-for-jx
+    scheduler: in-repo
   slack:
     channel: '#jenkins-x-pipelines'
     kind: failureOrNextSuccess


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the CI/CD configuration](https://jenkins-x.io/docs/v3/about/how-it-works/#importing--creating-quickstarts) which will create a second commit on this Pull Request before it auto merges
